### PR TITLE
script to create a nonreacting multi-mixture fraction table for spray vaporization

### DIFF
--- a/get_spray_nd_table.py
+++ b/get_spray_nd_table.py
@@ -1,0 +1,77 @@
+import cantera as ct
+import ctable_tools
+import pandas as pd
+import toml
+import sys
+import numpy as np
+
+# Load inputs
+if len(sys.argv) != 2:
+    raise RuntimeError("Invalid Usage: input file is single command line argument")
+infile = sys.argv[1]
+try:
+    with open(infile) as tomlfile:
+       inputs = toml.load(tomlfile)
+except FileNotFoundError:
+    raise FileNotFoundError("Input file < " + sys.argv[1] + " > not found!")
+iphys = inputs["phys"]
+itable = inputs["table"]
+
+# Create mixing streams
+ox = ct.Solution(iphys["mechanism"])
+ox.TPX = iphys["T_ox"], iphys["pressure"], iphys["X_ox"]
+oxstream = ct.Quantity(ox, constant="HP")
+fuelstreams = []
+Nfuel = len(iphys["X_fuel"])
+for ii, fcomps in enumerate(iphys["X_fuel"]):
+    fu = ct.Solution(iphys["mechanism"])
+    fu.TPX = iphys["liqTfuel"][ii], iphys["pressure"], iphys["X_fuel"][ii]
+    # account for enthalpy of vaporization
+    fu.HPX = fu.enthalpy_mass - iphys["deltaHvap"][ii], fu.P, fu.Y
+    fuelstreams.append(ct.Quantity(fu,constant="HP"))
+    print("Fuel stream {} ({}): liquid T is {} and gaseous T is {}".format(ii, iphys["X_fuel"][ii], iphys["liqTfuel"][ii], fu.T))
+streams = [oxstream] + fuelstreams
+
+# Create table
+grids =[]
+for grid in itable["grid"][:Nfuel]:
+    grids.append(np.linspace(0.0,1.0,grid))
+if itable["use_fmix"]:
+    dimnames = ["ZMIX"]
+    for ii in range(Nfuel - 1):
+        dimnames.append("FMIX"+str(ii))
+else:
+    dimnames = ["ZMIX"+str(ii) for ii in range(Nfuel)]
+
+dfindex = pd.MultiIndex.from_product(grids, names=dimnames)
+dfcols = ["T","RHO","DIFF","VISC"]+["Y-"+spec.split(":")[0] for spec in iphys["X_fuel"]]
+df = pd.DataFrame(index=dfindex, columns=dfcols, dtype=np.float64)
+
+for comp in dfindex:
+    remainder = 1.0
+    comps = np.array(comp)
+    if itable["use_fmix"]:
+        comps[0] = 1 - comps[0]
+        for ii, stream in enumerate(streams[:-1]):
+            stream.mass = remainder * comps[ii]
+            remainder = remainder * (1 - comps[ii])
+        streams[-1].mass = remainder
+    else:
+        for ii, stream in enumerate(streams[1:]):
+            strm_mass = min(remainder, comps[ii])
+            remainder = remainder - strm_mass
+            stream.mass = strm_mass
+            print(ii, comps, remainder)
+        streams[0].mass = remainder
+    nonzeromass = [stream.mass > 0.0 for stream in streams]
+    mixture = np.sum(np.array(streams)[nonzeromass])
+    df.loc[comp] = ([mixture.T, mixture.density, mixture.thermal_conductivity/mixture.cp, mixture.viscosity]
+                + [mixture.Y[mixture.species_index(spec.split(":")[0])] for spec in iphys["X_fuel"]])
+    print (df.loc[comp]["RHO"])
+
+ctable_tools.convert_chemtable_units(df, "mks2cgs")
+print(df)
+df["RHOinv"] = 1.0/df["RHO"]
+df["lnRHO"] = np.log(np.array(df["RHO"]))
+
+ctable_tools.write_chemtable_binary(itable["filename"], df, "mixing-only")

--- a/spray_nd.inp
+++ b/spray_nd.inp
@@ -1,0 +1,13 @@
+[phys]
+mechanism = "~/Software/PeleLMeXclean/Submodules/PelePhysics/Mechanisms/liquid_fuels_nonreacting/mechanism.yaml"
+pressure = 101325 # Pa
+X_ox = "O2:0.21, N2:0.79"
+T_ox = 300 # K
+X_fuel = ["NC7H16:1.0", "NC10H22:1.0", "NC12H26:1.0"] # should all be pure components
+liqTfuel = [400.0, 500.0, 600.0] # 1 per fuel, K
+deltaHvap = [300000, 330000, 340000] # 1 per fuel, J/kg
+
+[table]
+use_fmix = false
+grid = [10, 11, 12] # must have N_fuels dimensions
+filename = "two_fuel_mixing.ctb"


### PR DESCRIPTION
Create a table with an arbitrary number of mixture fractions corresponding to liquid fuel vaporization.

Run using `python get_spray_nd_table.py spray_nd.inp`. 

In inputs, if `use_fmix = false` then tabulation is done in terms of mixture fractions corresponding to each liquid fuel component (the balance of the mixture is air). A full (hyper)-cube table is generated but only the lower simplex contains valid data because mixture fractions must sum to unity. 

If `use_fmix = true`, the tabulation is done in terms of a single mixture fraction (corresponding to fuel/air mixing accounting for the sum of all fuels) and N-1 fuel premixing fractions indicating the fuel composition.