### PR TITLE
deprecate SHERPA because it has gone stale

### DIFF
--- a/manifold_reduction_nets.py
+++ b/manifold_reduction_nets.py
@@ -6,17 +6,16 @@ from collections import OrderedDict, namedtuple
 from net_array import NetArray, MRNetArray
 import copy
 import os
-import sherpa
 import pandas as pd
 import matplotlib.pyplot as plt
 
 # ========================================================================
 def combine_lossfuncs(*funcs):
-    
+
     def combo(pred, actual):
-        
+
         return sum(f(pred, actual) for f in funcs)
-        
+
     return combo
 
 # ========================================================================
@@ -60,7 +59,7 @@ class netstruct_loss:
             for param in params:
                 loss += torch.norm(param,1)
         return self.lam1 * self.calc_ramp(epoch) * loss
-        
+
 # ========================================================================
 # Loss due to source terms having the wrong sign
 def sgn_loss(idx, alpha=1.0, beta=1e-10):
@@ -68,23 +67,23 @@ def sgn_loss(idx, alpha=1.0, beta=1e-10):
     Alpha is the total loss for each incorrect sign where magnitude is > beta. Beta is the
     linearity threshold.
     """
-    
+
     def lossfunc(pred, actual):
-        
+
         t = pred[:, idx]*actual[:, idx]
         return -alpha/beta * t.clamp(-beta, 0.0).sum() / t.numel()
-        
+
     return lossfunc
-    
+
 def sgn_loss_mpar(idx, alpha=1.0, beta=1e-10):
     """
     Alpha is the total loss for each incorrect sign where magnitude is > beta. Beta is the
     linearity threshold. This function acts on the manifold parameter sources, and not the
     raw source terms.
     """
-    
+
     def lossfunc(pred, actual, model, scalers):
-        
+
         # Unscaled net parameters
         maniweights = model.unscaled_maniweights(scalers['inp'].scale_)
         manibiases = model.unscaled_manibiases(scalers['inp'].mean_)
@@ -93,23 +92,23 @@ def sgn_loss_mpar(idx, alpha=1.0, beta=1e-10):
             outbias = torch.Tensor(scalers['out'].mean_)
         else:
             outbias = 0.0
-            
+
         pred = pred*outscale + outbias
         actual = actual*outscale + outbias
-        
+
         mask = idx < 0
         pred_src = pred[:, idx]
         pred_src[:, mask] = 0.0
         actual_src = actual[:, idx]
         actual_src[:, mask] = 0.0
-        
+
         # Biases are length nmanipar
         # Weights are nmanipar × ncomb
         pred_src = (pred_src @ maniweights) + manibiases
         actual_src = (actual_src @ maniweights) + manibiases
         t = pred_src*actual_src
         return -alpha/beta * t.clamp(-beta, 0.0).sum() / t.numel()
-        
+
     return lossfunc
 
 # ========================================================================
@@ -150,25 +149,25 @@ class PredictionNet(nn.Module):
         self.output = nn.Sequential(
             nn.LeakyReLU(), nn.BatchNorm1d(H[-1]), nn.Linear(H[-1], D_out)
         )
-        
+
     def trainable_manifold(self):
-        
+
         return False
-    
+
     def set_unscaled_manidef(self, scaler_scale, scaler_mean, dev):
-        
+
         self._maniweights = (self.inputs['manidef'].T / scaler_scale).T.to(device=dev)
         # Assumes existing biases are 0
         self._manibiases = -torch.matmul(self.inputs['manidef'].T, scaler_mean).to(device=dev)
-        
+
     def unscaled_maniweights(self, scaler_scale, transpose=False):
-        
+
         if transpose:
             return self._maniweights.T
         return self._maniweights
-        
+
     def unscaled_manibiases(self, scaler_mean):
-        
+
         return self._manibiases
 
     # Calculates only the manifold variables
@@ -205,7 +204,7 @@ class PredictionNet(nn.Module):
         out = self.hidden(out)
         out = self.output(out)
         return out
-        
+
     def copy_state(self):
         net = self.__class__(**self.inputs)
         net.load_state_dict(self.state_dict())
@@ -213,10 +212,10 @@ class PredictionNet(nn.Module):
 
     def get_inputs(self):
         return copy.deepcopy(self.inputs)
-        
+
     def unscaled(self, scalers, compute_mani_source=False, src_term_map=None, outslice=None):
         return unscale_prediction_net(self, scalers, compute_mani_source, src_term_map, outslice)
-            
+
     @property
     def nout(self):
         return self.D_out
@@ -249,8 +248,8 @@ def unscale_prediction_net(PredNet, scalers, compute_mani_source=False, src_term
     statedict['output.2.bias'] *= torch.Tensor(outscale)
     if (scalers['out'].with_mean):
         statedict['output.2.bias'] += torch.Tensor(outmean)
-    
-    if src_term_map is not None:    
+
+    if src_term_map is not None:
         src_term_map = np.array([src_term_map[0], src_term_map[1]-outslice.start])
 
     # Add outputs for the manifold parameter source terms
@@ -343,21 +342,21 @@ class ManifoldReductionNet(nn.Module):
         return torch.cat((out1, out2, out3),1)
 
     def trainable_manifold(self):
-        
+
         return True
-        
+
     def unscaled_maniweights(self, scaler_scale, transpose=False):
-        
+
         maniweights = self.manifold.parameters() / scaler_scale
         if transpose:
             return maniweights
         return maniweights.T
-        
+
     def unscaled_manibiases(self, scaler_mean):
 
         # Assumes existing biases are 0
         return -torch.matmul(self.manifold.parameters(), scaler_mean)
-        
+
     def mapfrom_manifold(self,xmani):
         out = self.inp(xmani)
         out = self.hidden(out)
@@ -448,7 +447,7 @@ def train_net(XTrain, YTrain, Xval, Yval, model,
         Yt = YTrain
         Xv = Xval
         Yv = Yval
-        
+
     if calc_srcloss and not ondev:
         if not model.trainable_manifold():
             scaler_scale = torch.Tensor(scalers['inp'].scale_)
@@ -619,13 +618,13 @@ def copy_net(model, keep_manidef=True):
 
     elif model.net_type == 'FilteredManifoldReductionNet':
         new_model = FilteredManifoldReductionNet(**model.inputs)
-        
+
     elif model.net_type == "NetArray":
         new_model = NetArray(nets=[copy_net(net, keep_manidef) for net in model],
                 nouts=model.nout_iter(), **model.inputs)
-                
+
     elif model.net_type == "MRNetArray":
-        new_model = MRNetArray(copy.deepcopy(model.manifold), 
+        new_model = MRNetArray(copy.deepcopy(model.manifold),
                 nets=[copy_net(net, keep_manidef) for net in model],
                 nouts=model.nout_iter(), **model.inputs)
 
@@ -654,14 +653,21 @@ def train_net_sherpa(XTrain, YTrain, Xval, Yval, model_in,
                      save_chk =False,
                      increase_bs=False):
 
+    # Ensure we're not actually using SHERPA which is deprecated
+    assert ngenerations == 1, "Can't use SHERPA, ngenerations must be 1"
+    assert nsiblings == 1, "Can't use SHERPA, nsiblings must be 1"
+    assert len(batchsize) == 1, "Can't use SHERPA, provide only 1 batchsize"
+    assert learning_rate[0] == learning_rate[1], "Can't use SHERPA, provide only 1 learning_rate"
+
     # make the output directory:
     if not os.path.exists(savepath): os.makedirs(savepath)
 
-    parameters = [sherpa.Continuous('lr', learning_rate, scale='log'),
-                  sherpa.Ordinal('batchsize', batchsize)]
-    algorithm = sherpa.algorithms.PopulationBasedTraining(population_size = nsiblings,
-                                                          num_generations = ngenerations,
-                                                          perturbation_factors = (0.1,1,10) )
+    #parameters = [sherpa.Continuous('lr', learning_rate, scale='log'),
+    #              sherpa.Ordinal('batchsize', batchsize)]
+    #algorithm = sherpa.algorithms.PopulationBasedTraining(population_size = nsiblings,
+    #                                                      num_generations = ngenerations,
+    #                                                      perturbation_factors = (0.1,1,10) )
+
     if plot_dashboard is not None:
         fig = plt.figure(plot_dashboard,figsize=[12,4])
         axTL = plt.subplot(221)
@@ -680,9 +686,9 @@ def train_net_sherpa(XTrain, YTrain, Xval, Yval, model_in,
         axBR.set_yscale('log')
         cmap = plt.get_cmap('tab20')
 
-    study = sherpa.Study(parameters=parameters,
-                         algorithm=algorithm,
-                         lower_is_better=True)
+    #study = sherpa.Study(parameters=parameters,
+    #                     algorithm=algorithm,
+    #                     lower_is_better=True)
 
     TL={}; VL={}; BS={}; LR={}; GEN ={}; hist ={};
 
@@ -691,17 +697,17 @@ def train_net_sherpa(XTrain, YTrain, Xval, Yval, model_in,
     Yt = Variable(torch.as_tensor(YTrain,dtype=torch.float).to(device=dev))
     Xv = Variable(torch.as_tensor(Xval,dtype=torch.float).to(device=dev))
     Yv = Variable(torch.as_tensor(Yval,dtype=torch.float).to(device=dev))
-    lossfunc = lossfunc.to(device = dev)      
-    
+    lossfunc = lossfunc.to(device = dev)
+
     if calc_srcloss:
         have_args = (srclossfunc is not None) and (scalers is not None)
         assert have_args, "Must supply srclossfunc and scalers if calc_srcloss is True"
         ScalerTuple = namedtuple("ScalerTuple", "scale_ mean_ with_mean")
-            
+
         # CPU version
         scaler_scale = torch.Tensor(scalers['inp'].scale_)
         scaler_mean = torch.Tensor(scalers['inp'].mean_)
-        
+
         # Move scalers to device
         devscl = dict()
         for k, v in scalers.items():
@@ -710,37 +716,38 @@ def train_net_sherpa(XTrain, YTrain, Xval, Yval, model_in,
                                         torch.Tensor(scalers[k].mean_ ).to(device=dev),
                                         True)
             else:
-                devscl[k] = (torch.Tensor(scalers[k].scale_).to(device=dev), None, False)        
+                devscl[k] = (torch.Tensor(scalers[k].scale_).to(device=dev), None, False)
         scalers = devscl
     else:
         scaler_scale = None
         scaler_mean = None
 
-    for trial in study:
+    for trial in [0]:
         # Get the parameters
-        generation   = trial.parameters['generation']
-        load_from    = trial.parameters['load_from']
-        save_to      = trial.parameters['save_to']
-        learningrate = trial.parameters['lr']
-        batchsize    = int(trial.parameters['batchsize'])
+        generation   = 0
+        load_from    = ""
+        learningrate = learning_rate[0]
+        batchsize    = batchsize[0]
+        trialid      = trial
+        save_to      = str(trial)
         print ("Starting trial {} in generation {}:     lr = {:8.4e}   bs = {:6n}"
-               .format(trial.id, generation,learningrate,batchsize))
+               .format(trialid, generation,learningrate,batchsize))
 
         # Get the model and optimizer and load if necessary
         model = copy_net(model_in)
-        
+
         if calc_srcloss and not model.trainable_manifold():
             model.set_unscaled_manidef(scaler_scale, scaler_mean, dev)
-            
+
         optimizer = optim.Adam(model.parameters(), lr=learningrate, amsgrad=True)
         if load_from != "":
             load_checkpoint(model, optimizer,
                             os.path.join(savepath, load_from + '.npz'), verbose=False )
 
-        GEN[trial.id] = generation; BS[trial.id] = batchsize; LR[trial.id] = learningrate
+        GEN[trialid] = generation; BS[trialid] = batchsize; LR[trialid] = learningrate
         model.to(device=dev)
         if save_chk is not False: save_chk = savepath
-        TL[trial.id], VL[trial.id], hist[trial.id] = train_net(Xt, Yt, Xv, Yv, model,
+        TL[trialid], VL[trialid], hist[trialid] = train_net(Xt, Yt, Xv, Yv, model,
                                                      batchsize=batchsize, nepochs=nepochs, dev=dev,
                                                      lossfunc = lossfunc, learning_rate=learningrate,
                                                      wgtlossfunc = wgtlossfunc, srclossfunc=srclossfunc,
@@ -749,14 +756,14 @@ def train_net_sherpa(XTrain, YTrain, Xval, Yval, model_in,
                                                      reduce_lr = reduce_lr, save_chk = save_chk,
                                                      increase_bs=increase_bs, return_full_hist = True)
         save_checkpoint(model, optimizer, os.path.join(savepath, save_to + '.npz') , verbose= False)
-        hist[trial.id] = pd.DataFrame(hist[trial.id])
-        hist[trial.id].to_csv(os.path.join(savepath, save_to + '.csv'))
-        study.add_observation(trial=trial, objective=VL[trial.id], iteration=int(generation))
-        study.finalize(trial=trial)
-        study.save(output_dir = savepath)
+        hist[trialid] = pd.DataFrame(hist[trialid])
+        hist[trialid].to_csv(os.path.join(savepath, save_to + '.csv'))
+        #study.add_observation(trial=trial, objective=VL[trialid], iteration=int(generation))
+        #study.finalize(trial=trial)
+        #study.save(output_dir = savepath)
 
         if plot_dashboard is not None:
-            child = trial.id
+            child = trialid
 
             hist[child].index += (GEN[child]-1)*nepochs+1
             if load_from != '':
@@ -777,12 +784,11 @@ def train_net_sherpa(XTrain, YTrain, Xval, Yval, model_in,
             os.remove('stop')
             break
 
-    best_trial = study.get_best_result()
-    best_id = best_trial['Trial-ID']
+    best_id = 0
     with open(os.path.join(savepath, 'best_trial.txt'),'w') as f:
         f.write("{}".format(best_id))
 
     load_checkpoint(model_in, optimizer,
-                    os.path.join(savepath, str(best_trial['Trial-ID']) + '.npz'), verbose=False )
+                    os.path.join(savepath, str(best_id) + '.npz'), verbose=False )
 
     return TL[best_id], VL[best_id]

--- a/net_helper.py
+++ b/net_helper.py
@@ -34,8 +34,9 @@ def convert_mol_mass(data):
            'OH' : 16.00 + 1.0079,
            'H2' : 2 * 1.0079,
            'CH4': 12.01 + 4*1.0079,
-           'H2O': 16.00 + 2 * 1.0079}
-    
+           'H2O': 16.00 + 2 * 1.0079,
+           'N2' : 2*14.01}
+
     for col in data.columns:
         if col.startswith('RR'):
             specname = col.split('_')[-1]
@@ -86,13 +87,13 @@ def load_and_scale_data(directory,
                                     if key != 'planes'})
             #for var in trndata.columns: print( var, np.min(trndata[var]), np.max(trndata[var]))
             tstdata = trndata.copy()
-        
+
     elif data_source == 'flamelet':
         trndata = pd.read_csv(directory)
         tstdata = pd.read_csv(directory)
     else:
         raise RuntimeError("invalid data source specification")
-    
+
     nsamples  = len(trndata.index)
     print('Training data set has {} samples'.format(nsamples))
     print('Testing  data set has {} samples'.format(len(tstdata.index)))
@@ -126,7 +127,7 @@ def load_and_scale_data(directory,
         return nsamples, trn_data, trndata['z (m)'], scalers
     else:
         return nsamples, trn_data, tst_data, scalers
-        
+
 def extract_variances(dataframe, trainvars, scaler):
     # Set up scaling information
     scales = dict(zip(trainvars,1.0/scaler.scale_))
@@ -134,7 +135,7 @@ def extract_variances(dataframe, trainvars, scaler):
         offsets = dict(zip(trainvars, -scaler.mean_/scaler.scale_))
     except:
         offsets = dict(zip(trainvars, np.zeros(len(trainvars))))
-        
+
     # Extract moments, verifying that all exist
     nmoments = len(trainvars) **2
     variances = np.zeros((len(dataframe.index), nmoments))
@@ -146,7 +147,7 @@ def extract_variances(dataframe, trainvars, scaler):
             variances[:,idex] = dataframe["~".join(reversed(moment))]
         else:
             raise RuntimeError("Moment " + "~".join(moment) + " not found in DataFrame")
-        
+
         variances[:,idex] = (scales[moment[0]]*scales[moment[1]]*variances[:,idex] +
                              scales[moment[0]]*offsets[moment[1]]*dataframe[moment[0]] +
                              scales[moment[1]]*offsets[moment[0]]*dataframe[moment[1]] +
@@ -166,7 +167,7 @@ class metadata:
     def save(self):
         np.savez(self.directory + '/metadata.npz',
                  dictionary = [self.__dict__,])
-        
+
     def __repr__(self):
         print('\n Metadata container with the following variables:\n')
         for key,val in self.__dict__.items():
@@ -174,26 +175,26 @@ class metadata:
             print(val)
             print('')
         return ('End container')
-        
+
     def save_net_info(self, fname, varname_converter=None):
         """Save to metadata file readable by PelePhysics."""
-        
+
         def insert_line_breaks(strs, breakpoint=100, prefix_len=11):
-            
+
             nchars = prefix_len
             ins_points = []
-            
+
             for i in range(len(strs)):
                 nchars += len(strs[i]) + 1
                 if nchars >= breakpoint-1:
                     ins_points.append(i)
                     nchars = prefix_len + len(strs[i]) + 1
-                    
+
             for i in range(len(ins_points)):
                 strs.insert(ins_points[i]+i, '\\\n'+' '*(prefix_len-1))
-        
+
         with open(fname, 'w') as file:
-            
+
             print("# Name of the neural network model", file=file)
             print(f"model_name = {self.model_name}", file=file)
             ndim = len(self.passvars) + self.nmanivars
@@ -204,7 +205,7 @@ class metadata:
             print(f"nvar = {nvar}", file=file)
             print("# Number of manifold parameters", file=file)
             print(f"nmanpar = {self.nmanivars}", file=file)
-            
+
             dimnames = list(map(varname_converter, self.passvars))
             dimnames += [f'xi{i}' for i in range(self.nmanivars)]
             dimnamelist = dimnames.copy()
@@ -212,22 +213,22 @@ class metadata:
             dimnames = ' '.join(dimnames)
             print("# Names of input variables", file=file)
             print(f"dimnames = {dimnames}", file=file)
-            
+
             varnames = list(map(varname_converter, self.predictvars))
             insert_line_breaks(varnames)
             varnames = ' '.join(varnames)
             print("# Names of output variables", file=file)
             print(f"varnames = {varnames}", file=file)
-            
+
             print("# Definitions of input variables", file=file)
-            
+
             for i in range(len(self.passvars)):
-                
+
                 pardef = dimnamelist[i]
                 print(f"def_{dimnamelist[i]} = {pardef}", file=file)
-                
+
             for i in range(len(self.passvars), len(dimnamelist)):
-                
+
                 weights = map(lambda w: str(w.item()), self.xidefs[i-len(self.passvars)])
                 pardef = zip(weights, '*'*len(self.trainvars), map(varname_converter, self.trainvars))
                 pardef = ["".join(x) for x in pardef]
@@ -235,7 +236,7 @@ class metadata:
                 insert_line_breaks(pardef, prefix_len=len(lhs)+3)
                 pardef = ' '.join(pardef)
                 print(f"{lhs} = {pardef}", file=file)
-                
+
             print("# Biases to be used calculating input variables", file=file)
             manibiases = ' '.join(map(lambda mb: str(mb.item()), self.manibiases))
             print(f"manibiases = {manibiases}", file=file)
@@ -253,7 +254,7 @@ def GetVarLims(var, lims=None, data=None, expandrange=True):
         raise RuntimeError("GetVarLims: must specify lims or data")
 
     get_from_data = True
-    
+
     if lims is not None:
         if var in lims.keys():
             minx, maxx = lims[var]
@@ -265,7 +266,7 @@ def GetVarLims(var, lims=None, data=None, expandrange=True):
         if expandrange:
             rwidth = maxx-minx
             center = (maxx + minx) /2
-            minx = center - 0.6*rwidth 
+            minx = center - 0.6*rwidth
             maxx = center + 0.6*rwidth
 
     return minx, maxx
@@ -274,20 +275,20 @@ def GetVarLims(var, lims=None, data=None, expandrange=True):
 def MakeManiDefPlots(outfile, md, model, lineage='', rescale=False, resign=False, with_legend=False, log=False):
 
     print('Making Mani Def plots')
-    
+
     labels = md.trainvars
     x = np.arange(len(labels))
-    width = 0.7/md.nmanivars 
+    width = 0.7/md.nmanivars
     offset = -0.5*(md.nmanivars - 1.0)
 
     figheight = 2 if not log else 2.5
     fig,ax = plt.subplots(figsize=(colors.twocol_figsize[0], figheight))
 
     scaleweights = model.inputs['manidef'].cpu().numpy().copy()
-    if rescale : scaleweights /= md.scalers['inp'].scale_[...,None] 
+    if rescale : scaleweights /= md.scalers['inp'].scale_[...,None]
     scaleweights /= np.max(np.abs(scaleweights),0)[None,...]
     # Below: multiply by -1 if max abs weight is negative
-    if resign : scaleweights *= np.diag(scaleweights[np.argmax(np.abs(scaleweights),0)] )[None,...]  
+    if resign : scaleweights *= np.diag(scaleweights[np.argmax(np.abs(scaleweights),0)] )[None,...]
 
     if log: scaleweights = np.abs(scaleweights)
 
@@ -324,13 +325,13 @@ def MakeManiDefPlots(outfile, md, model, lineage='', rescale=False, resign=False
         plt.close()
     plt.clf()
     plt.close()
-    
+
 # scatter plot in manifoldspace
-def MakeManiPlots(outfile, manivars, outdata=None, manivars2=None, outdata2=None, 
+def MakeManiPlots(outfile, manivars, outdata=None, manivars2=None, outdata2=None,
                   colorvars=['T (K)'], label='true', lineage='', nplot=20000, with_cb = False,
                   varlims=None, modify_ticks=True, filtered=False, c1='red', c2='black'):
     print('Making Mani Plots')
-    
+
     nsamples = manivars.shape[0]
     if nplot < nsamples:
         chosen = np.random.choice(nsamples,nplot)
@@ -342,7 +343,7 @@ def MakeManiPlots(outfile, manivars, outdata=None, manivars2=None, outdata2=None
             chosen2 = np.random.choice(nsamples2,nplot)
         else:
             chosen2 = np.arange(nsamples2)
-        
+
     if lineage is not '' : lineage = '_' + lineage
     for var in colorvars:
         plt.figure(figsize=(colors.twocol_figsize))
@@ -355,9 +356,9 @@ def MakeManiPlots(outfile, manivars, outdata=None, manivars2=None, outdata2=None
                         vmin=minc, vmax=maxc,s=0.4)
             plt.clim([minc,maxc])
 
-        else : 
+        else :
             plt.scatter(manivars[chosen,0],manivars[chosen,1],color=c1,s=0.4)
-                
+
         if manivars2 is not None:
             if outdata2 is not None:
                 plt.scatter(manivars2[chosen2,0],manivars2[chosen2,1],c=outdata2[var][chosen2],s=0.4)
@@ -371,7 +372,7 @@ def MakeManiPlots(outfile, manivars, outdata=None, manivars2=None, outdata2=None
         else:
             plt.xlabel(r'$\widetilde{\xi}_1$')
             plt.ylabel(r'$\widetilde{\xi}_2$')
-            
+
         if modify_ticks:
             plt.gca().xaxis.set_major_locator(ticker.MultipleLocator(2))
             plt.gca().yaxis.set_major_locator(ticker.MultipleLocator(2))
@@ -382,7 +383,7 @@ def MakeManiPlots(outfile, manivars, outdata=None, manivars2=None, outdata2=None
         lim = plt.gca().get_ylim()
         plt.ylim([lim[0] if lim[0] < -minlim else -minlim, lim[1] if lim[1] > minlim else minlim])
         #plt.gcf().tight_layout()
-        
+
         plt.gca().set_position(colors.twocol_figbounds)
         plt.savefig(outfile + '/mani_' + label + '_' + var.split(' ')[0]+ lineage+'.png', dpi=150)
         if with_cb:
@@ -397,7 +398,7 @@ def MakeManiPlots(outfile, manivars, outdata=None, manivars2=None, outdata2=None
         plt.clf()
         plt.close()
 
-def MakeParityPlotsVec(outfile, true_values_vec, pred_values_vec, 
+def MakeParityPlotsVec(outfile, true_values_vec, pred_values_vec,
                        parityvars=['T (K)'], filtered=False,
                        lineage='', nplot=20000, varlims=None,
                        colors_vec = ['r','k'], labels_vec=['Training','Validation'], val_labels=['Validation']):
@@ -407,7 +408,7 @@ def MakeParityPlotsVec(outfile, true_values_vec, pred_values_vec,
 
     for var in parityvars:
         plt.figure(var, figsize = colors.twocol_figsize)
-    
+
     for ii in range(len(true_values_vec)):
         nsamples = true_values_vec[ii].shape[0]
         if nplot < nsamples:
@@ -416,7 +417,7 @@ def MakeParityPlotsVec(outfile, true_values_vec, pred_values_vec,
             chosen = np.arange(nsamples)
 
         lab = ' - ' + labels_vec[ii] if labels_vec[ii] != '' else ''
-            
+
         for var in parityvars:
             plt.figure(var)
             r2 = r2_score(true_values_vec[ii][var], pred_values_vec[ii][var])
@@ -425,7 +426,7 @@ def MakeParityPlotsVec(outfile, true_values_vec, pred_values_vec,
 
     for var in parityvars:
         plt.figure(var)
-        
+
         handles, labels = plt.gca().get_legend_handles_labels()
         handles_val = [handle for handle, label in zip(handles, labels) if any([val_label in label for val_label in val_labels])]
         labels_val = [label for label in labels if any([val_label in label for val_label in val_labels])]
@@ -435,12 +436,12 @@ def MakeParityPlotsVec(outfile, true_values_vec, pred_values_vec,
         leg1 = plt.legend(handles_val, labels_val, frameon=False, loc='upper left', title= 'Validation',
                    scatterpoints=4, handlelength=0.9, handletextpad=0.2,
                    labelspacing=0.1,  fontsize='small', borderpad=0.05)
-        
+
         leg2 = plt.legend(handles_trn, labels_trn, frameon=False, loc='lower right', title='Training',
                    scatterpoints=4, handlelength=0.9, handletextpad=0.2,
                    labelspacing=0.1,  fontsize='small', borderpad=0.05)
         plt.gca().add_artist(leg1)
-        
+
         minx, maxx = GetVarLims(var, lims=varlims, data=true_values_vec[0])
         plt.xlim([minx,maxx])
         plt.ylim([minx,maxx])
@@ -452,7 +453,7 @@ def MakeParityPlotsVec(outfile, true_values_vec, pred_values_vec,
         plt.savefig(outfile + '/parity_' + var.split(' ')[0] + lineage + '.png', dpi=150)
         plt.clf()
         plt.close()
-            
+
 # scatter parity plot
 def MakeParityPlots(outfile,
                     true_out_tst, pred_out_tst,
@@ -462,20 +463,20 @@ def MakeParityPlots(outfile,
                     lab2='Training', lab1='Validation',
                     c2='k',c1='r', filtered=False):
     print('Making parity plots')
-    
+
     if true_out_trn is not None:
         nsamples_trn = true_out_trn.shape[0]
         if nplot < nsamples_trn:
             chosen_trn = np.random.choice(nsamples_trn,nplot)
         else:
             chosen_trn = np.arange(nsamples_trn)
-    
+
     nsamples_tst = true_out_tst.shape[0]
     if nplot < nsamples_tst:
         chosen_tst = np.random.choice(nsamples_tst,nplot)
     else:
         chosen_tst = np.arange(nsamples_tst)
-    
+
     if lineage is not '' : lineage = '_' + lineage
     for var in parityvars:
         plt.figure(figsize=(colors.twocol_figsize))
@@ -507,14 +508,14 @@ def MakeParityPlots(outfile,
 def MakeSlicePlots(outfile, data, slicevars, nmanivars=0, nvars=0, size=(832,832), name='',
                    lab='',varlims=None, with_cb=False, crop=0, figsize=(4,4), scalebar=None, filtered=False):
     print('Making slice plots')
-    
+
     # Attach column names if plotting manifold variables
     if nmanivars > 0:
         slicevars = ['xi_'+str(manivar+1) for manivar in range(nmanivars)]
         if nvars > 0:
             slicevars += ['xi_var_'+str(ivar+1) for ivar in range(nvars)]
         data = pd.DataFrame(data[:,:nmanivars+nvars].numpy(),columns=slicevars)
-    
+
     #name = name.split('/')[-1].split('_')[0] + '_'
     name = name.split('/')[-1].replace('.h5','_')
 
@@ -524,7 +525,7 @@ def MakeSlicePlots(outfile, data, slicevars, nmanivars=0, nvars=0, size=(832,832
             cropy = 0; cropx =0;
             res = plt.imshow(data[var].to_numpy().reshape(size)[:,:])
         elif isinstance(crop,int):
-            cropx = crop; cropy = crop 
+            cropx = crop; cropy = crop
             plotdata = data[var].to_numpy().reshape(size)[crop:-crop,crop:-crop]
             print('cropping to ', plotdata.shape)
             res = plt.imshow(plotdata)
@@ -568,15 +569,15 @@ def MakeSlicePlots(outfile, data, slicevars, nmanivars=0, nvars=0, size=(832,832
             plt.savefig(outfile +'/slice_'+ name + var.split(' ')[0] + '_' + lab + '_cb.png', dpi=150)
             plt.clf()
             plt.close()
-            
-            
+
+
         plt.savefig(outfile +'/slice_'+ name + var.split(' ')[0] + '_' + lab +'.png', dpi=150)
         plt.clf()
         plt.close()
 
 
-    
-                   
+
+
 if __name__ == "__main__":
     import sys
     fname = sys.argv[1]

--- a/plot_strained.py
+++ b/plot_strained.py
@@ -59,11 +59,7 @@ for subdir in ['raw-pca-2', 'raw-cmlm-2', 'raw-fgm-2']:
     outdata = {}
     md = nh.metadata(os.path.join(savepath))
     md.load()
-    trial_results = pd.read_csv(os.path.join(savepath, subdir, 'results.csv'))
-    trial_results = trial_results[trial_results['Status']=='COMPLETED']
-    trial_results = trial_results.sort_values(by='Objective')
-    ntrials = trial_results.shape[0]
-    trials = [str(trial) for trial in trial_results['Trial-ID'] ]
+    trials = ["0"]
     val_loss = []
     trn_loss = []
     for trial in trials[0:1]:
@@ -111,7 +107,7 @@ for subdir in ['raw-pca-2', 'raw-cmlm-2', 'raw-fgm-2']:
                 print(np.min(invars.detach().cpu().numpy(),axis=0))
                 print(np.max(invars.detach().cpu().numpy(),axis=0))
                 print(model.inputs['manidef'])
-            
+
             nh.convert_mol_mass(outpred)
             nh.convert_mol_mass(outtrue)
             nh.convert_mol_mass(outpred_trn)
@@ -124,7 +120,7 @@ for subdir in ['raw-pca-2', 'raw-cmlm-2', 'raw-fgm-2']:
                                parityvars=plotvars, varlims=varlims, lineage=str(order),
                                c1=colors.get_color(color='blue',shade='d') ,
                                c2=colors.get_color(color='blue',shade='l') )
-            
+
             invars = get_invars(tst_nom,model)
             outpred = (pd.DataFrame(md.scalers['out'].inverse_transform(model(invars).detach().cpu().numpy()), columns=md.predictvars))
             outtrue = (pd.DataFrame(md.scalers['out'].inverse_transform(tst_nom['out']                     ), columns=md.predictvars))
@@ -139,12 +135,12 @@ for subdir in ['raw-pca-2', 'raw-cmlm-2', 'raw-fgm-2']:
                 print(np.min(invars.detach().cpu().numpy(),axis=0))
                 print(np.max(invars.detach().cpu().numpy(),axis=0))
                 print(model.inputs['manidef'])
-            
+
             nh.convert_mol_mass(outpred)
             nh.convert_mol_mass(outtrue)
             nh.convert_mol_mass(outpred_trn)
             nh.convert_mol_mass(outtrue_trn)
-            
+
             if flip:
                 invars_trn[:,0] *=-1
                 invars[:,0] *= -1
@@ -152,6 +148,3 @@ for subdir in ['raw-pca-2', 'raw-cmlm-2', 'raw-fgm-2']:
             invars[:,1] *= -1
             nh.MakeManiPlots(filename, invars_trn[:,:md.nmanivars], outtrue_trn,
                              label='true', lineage=str(order), with_cb=True, modify_ticks=True)
-
-
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,10 +13,13 @@ scipy = "^1.11.2"
 numpy = "^1.25.2"
 sympy = "^1.12"
 pandas = ">=2.0.3"
+torch = "^2.7.1"
+scikit-learn = "^1.7.0"
+h5py = "^3.14.0"
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 ipython = "^8.14.0"
 
 [build-system]
-requires = ["poetry-core>=1.0.0"]
+requires = ["poetry-core^2.0.0"]
 build-backend = "poetry.core.masonry.api"

--- a/train_models_strained_flames_raw.py
+++ b/train_models_strained_flames_raw.py
@@ -16,7 +16,7 @@ torch.manual_seed(42)
 np.random.seed(42)
 
 # options
-useGPU = True
+useGPU = False
 
 # directory where everything will be saved
 savepath = 'saved_networks/strained/'
@@ -30,10 +30,10 @@ md.network = (100,100)                                                  # networ
 md.loss_alpha  = 0.01                                                   # regularization parameter
 md.nmanivars = 2                                                        # dimensionality of manifold
 md.save_chk = False                                                     # save network at every epoch when training
-md.fuel = 'POSF10325'                                                   # Fuel species 
+md.fuel = 'POSF10325'                                                   # Fuel species
 
 # Whether or not to use SHERPA population-based training for hyperparameter optimization
-md.use_sherpa = False                                                 
+md.use_sherpa = False
 # Net training options - for SHERPA population based (expensive)
 if md.use_sherpa:
     md.batchsize = [512,1024,2048,4096,8192,16384]
@@ -52,7 +52,7 @@ else:
     md.nsibs = 1 ## FIXME
     md.reduce_lr = 3
     md.stop_no_progress = 10
-    
+
 # Variables that the manifold variables may be linear combinations of
 md.trainvars = np.array(['CO2','H2','N2','CO','O2','H2O',md.fuel,'OH'])
 
@@ -62,9 +62,9 @@ md.passvars = np.array([])
 
 # Variables that get predicted by the prediction net
 # md.predictvars = np.array(['CO2','H2','N2','CO','O2','H2O', md.fuel,'OH','CH2O','HO2',
-#                            'RR_H2O','RR_H2','RR_CO2','RR_CO', 'RR_'+md.fuel, 'RR_OH', 'RR_O2', 
+#                            'RR_H2O','RR_H2','RR_CO2','RR_CO', 'RR_'+md.fuel, 'RR_OH', 'RR_O2',
 #                            'RR_N2', 'T (K)', 'density'])
-                           
+
 md.predictvars = np.array(list(md.trainvars) + list(map(lambda s: 'RR_'+s, md.trainvars)) +
         ['CH2O', 'H2O', 'T (K)', 'density'])
 
@@ -194,14 +194,14 @@ torch.jit.script(pred_net).save("net.pt")
 
 # Save metadata in PelePhysics-readable format
 def munge_varname(s):
-    
+
     s = s.split()[0].upper()
     if s.startswith("RR_"):
         return "SRC_" + s[3:]
     if s == 'DENSITY':
         return 'RHO'
     return s
-    
+
 md.xidefs = pred_net.inputs['manidef'].T
 md.manibiases = pred_net.inputs['manibiases']
 md.save_net_info("net_info.txt", varname_converter=munge_varname)


### PR DESCRIPTION
[SHERPA ](https://github.com/sherpa-ai/sherpa) has gone stale and is not longer compatible with more recent versions of other python libraries like pandas (https://github.com/sherpa-ai/sherpa/issues/118), so remove it as a dependency.

leave the `train_net_sherpa` function in place because it is called by various scripts, but modify it so it doesn't actually use SHERPA, consistent with `use_sherpa=False` in the various training scripts.

Add `torch` to the pyproject.toml file so the dependency version can be managed (everything needed for the ML training scripts can now be installed with `poetry update`).